### PR TITLE
Cleanup teardown

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -14,6 +14,10 @@ type Reader struct {
 	Pr int       // priority
 }
 
+func (rr *Reader) Close() error {
+	return nil
+}
+
 // Read reads from R by b.
 func (rr *Reader) Read(p []byte) (n int, err error) {
 	if rr.B == nil {


### PR DESCRIPTION
Main problem is that this is racy:
```
	select {
	case bu.stopCh <- struct{}{}:
	default:
	}
```
You see this from time-to-time. However, you can actually end up in the default case incorrectly if the `timer` routine is busy and not actively receiving on the `stopCh` channel.